### PR TITLE
【Fixed】pry-rails,better_errors,binding_of_callerをdevelopment環境のみに

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'bcrypt', '~> 3.1.7', :require => 'bcrypt'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry-rails'
-  gem 'better_errors'
-  gem 'binding_of_caller'
 end
 
 group :development do
@@ -28,6 +25,9 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :test do


### PR DESCRIPTION
#2

debug用のgem、pry-rails,better_errors,binding_of_callerをGemfileのdevelopment下に移した